### PR TITLE
Improve heading structure in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,15 @@ This repository contains various country-specific metadata, for example whether 
 
 This data collection has been created for and is maintained for [StreetComplete](https://github.com/streetcomplete/StreetComplete/), however it may be useful for other users as well.
 
-# License
+## License
 
 [CC-0 1.0](https://creativecommons.org/publicdomain/zero/1.0/) (Public Domain)
 
-# Contributing
+## Contributing
 
 When adding new or updating existing information, please always provide a verifiable source, best as a comment on the same line.
 
-# Users
+## Users
 
 - [StreetComplete](https://github.com/streetcomplete/StreetComplete/) uses most of this data to localize the user interface, both in appearance and in behavior
 - [A/B Street](https://github.com/a-b-street/abstreet) uses some of this data to localize the rendering of streets


### PR DESCRIPTION
These headings should be below the main `# Country Metadata` heading.