### PR TITLE
Advisory speed limit signs in Latvia

### DIFF
--- a/data/hasAdvisorySpeedLimitSign.yml
+++ b/data/hasAdvisorySpeedLimitSign.yml
@@ -20,6 +20,7 @@ IS: false
 IE: false
 IT: true
 LU: true
+LV: true # https://likumi.lv/ta/id/274865-celu-satiksmes-noteikumi 4.pielikums. Ceļa zīmes; 7. Virzienu rādītāji un informācijas zīmes; 725 Ieteicamais ātrums
 'NO': true
 PL: false
 PT: true


### PR DESCRIPTION
Here in Latvia we do have advisory speed limit signs that look like this: ![Latvian advisory speed limit sign](https://likumi.lv/wwwraksti/2015/121/BILDES/N_279/IMAGE284.JPG)

I've included a reference to Latvian regulations. They are in Latvian, I hope it is OK.