### PR TITLE
Correct/update Japan centre line style

### DIFF
--- a/data/centerLineStyle.yml
+++ b/data/centerLineStyle.yml
@@ -43,7 +43,7 @@ ID: white
 IE: white
 JA: white
 JO: yellow
-JP: yellow # http://www.adcidl.com/pdf/Japan-Road-Traffic-Signs.pdf and https://www.google.de/maps/@35.2136797,136.9334556,3a,75y,212.49h,75.62t/data=!3m9!1e1!3m7!1swtaFZzLtROfi0N9hNUzPlw!2e0!7i16384!8i8192!9m2!1b1!2i66
+JP: white # https://www.google.de/maps/@35.7028317,139.7504802,3a,75y,358.88h,65.55t/data=!3m6!1e1!3m4!1sFjYMXFMoLyGbUprcY-PMUw!2e0!7i16384!8i8192?entry=ttu
 KE: yellow # https://www.google.de/maps/@-1.2846981,36.8238746,3a,75y,53.16h,71.44t/data=!3m9!1e1!3m7!1sQybKdAbDCWu-VY8uXu1DKQ!2e0!7i13312!8i6656!9m2!1b1!2i54
 KH: yellow
 KP: white


### PR DESCRIPTION
In my experience I saw a lot more/almost exclusively white in various parts of the country.

See https://en.wikipedia.org/wiki/Road_signs_in_Japan#/media/File:Japanese_road_sign_lanes_guide_installed_overhead.jpg too (as well as the Google Maps location I updated to).

Unfortunately I can't see a Japanese expert in https://github.com/osmlab/name-suggestion-index/issues/2588

