### PR TITLE
Add Wisconsin address check

### DIFF
--- a/data/additionalValidHousenumberRegex.yml
+++ b/data/additionalValidHousenumberRegex.yml
@@ -4,6 +4,9 @@
 AU: ([\p{N}\p{L}]{1,2}\s?/\s?|\p{L}{1,2}\s?)?\p{N}{1,5}
 ES: s/n
 FR: \p{N}{1,4}\sbis
+# e.g. "N123E1234", "S1234", "N123-E1234", "N123 E1234", "E1234A"
+# As of 29/1/2024 this matches almost all of the addr:housenumber in WI that start with a directional letter.
+US-WI: ^([NSEW][0-9]{1,5}[ -]?){1,2}[A-Z]?$
 # e.g. "1099A", "1806/127/2/6/15/48/2A", "73B/563B bis", "40bis/1", "35N/1C", "42/7bis", "L1004A",
 # see https://github.com/streetcomplete/StreetComplete/pull/3874
 VN: \p{L}?(?:\p{N}{1,4}(?:\s?(?:bis|ter|kép|\p{L}))?/)*\p{N}{1,4}(?:\s?(?:bis|ter|kép|\p{L})(?:\s(?:bis|ter|kép|\p{L}))?)?


### PR DESCRIPTION
Wisconsin has a somewhat unusual house numbering scheme discussed here: https://www.jsonline.com/story/life/green-sheet/2022/03/08/why-wisconsins-address-so-long-weird-and-full-numbers-rural-grid-format/6666606001/

This check matches the all but ~40 of the ~70,000 addr:housenumber in WI that start with [NSEW]. 

![image](https://github.com/streetcomplete/countrymetadata/assets/118567155/0d0cd42e-937a-4440-a32b-e1f66c423f22)


