### PR TITLE
Add metrics to the U.S. length unit options.

### DIFF
--- a/data/lengthUnits.yml
+++ b/data/lengthUnits.yml
@@ -43,7 +43,7 @@ MS: [meter, foot and inch] # British Overseas Territory
 PR: [foot and inch, meter] # territory of the US
 PW: [foot and inch, meter] # same as Micronesia (FM) because it is part of it
 TC: [meter, foot and inch] # British Overseas Territory
-US: [foot and inch]
+US: [meter, foot and inch] # The U.S. does not mandate the exclusive use of customary units, the national policy favors metric adoption, and both systems coexist in various contexts.
 VC: [foot and inch, meter] # mainly imperial units used
 VG: [foot and inch, meter] # mainly imperial units used
 VI: [foot and inch, meter] # mainly imperial units used


### PR DESCRIPTION
Though Imperial-like measurements are still used throughout the U.S., it is only because of inertia.

According to the U.S. National Intitute of Standards and Technology (NIST), from https://www.nist.gov/pml/owm/metrication-law :

> The U.S. Congress has established a national [policy](https://www.nist.gov/pml/owm/metric-si/metric-policy) of increasing the voluntary use of the metric system as the preferred system of measurement for trade and commerce in the United States. It is this national policy that places the decision and pace of metric use in the hands of individual companies, organizations, and persons. Currently, U.S. law permits the use of either the SI (International System of Units) or the U.S. customary measurement system. Although NIST is a non-regulatory agency, the adoption of SI practices is encouraged whenever possible.
> 
> [Metric Policy](https://www.nist.gov/pml/owm/metric-si/metric-policy) in the United States has had an extensive history. The [Metric Act of 1866](https://www.nist.gov/document/hr-596-metric-law-1866pdf) legalized the use of the metric system in America. Although many believe the United States does not use the metric system, Congress declared the metric system to be the preferred system of weights and measures for trade and commerce in 1988 with the Omnibus Trade and Competitiveness Act amendment to the [Metric Conversion Act of 1975](https://www.law.cornell.edu/uscode/text/15/chapter-6/subchapter-II). Additionally, this act required federal agencies to implement metric measures wherever feasible. Current customary measurement units are defined by the SI; mass, length, and volume have been defined by metric units since the [Mendenhall Order of 1893](https://usma.org/laws-and-bills/mendenhall-order).
> 