### PR TITLE
Set defaultSpeedLimitHasUrbanOrRural to false for US-MI

### DIFF
--- a/data/defaultSpeedLimitHasUrbanOrRural.yml
+++ b/data/defaultSpeedLimitHasUrbanOrRural.yml
@@ -208,7 +208,7 @@ US-LA: false
 US-MA: true
 US-MD: true
 US-ME: true
-US-MI: true
+US-MI: false
 US-MN: true
 US-MO: true
 US-MS: false


### PR DESCRIPTION
Unfortunately, Michigan's default speed limit law cannot be represented using US:rural and US:urban.
See https://wiki.openstreetmap.org/wiki/Michigan#Speed_limits
