### PR TITLE
add Bulgarian addresses

### DIFF
--- a/data/additionalValidHousenumberRegex.yml
+++ b/data/additionalValidHousenumberRegex.yml
@@ -5,6 +5,8 @@
 
 # in Australia, the unit number (sometimes?) prefixes the housenumber proper e.g. 1/50, see https://github.com/streetcomplete/StreetComplete/issues/4196
 AU: '([\p{N}\p{L}]{1,2}\s?/\s?|\p{L}{1,2}\s?)?\p{N}{1,5}'
+# see https://github.com/streetcomplete/StreetComplete/issues/5683#issuecomment-2163488046
+BG: '((бл\.\s?)?\p{N}{1,4}[\s-]?\p{L}?)|((\p{N}{1,4}-)*\p{N}{1,4})'
 ES: 's/n'
 FR: '\p{N}{1,4}\sbis'
 # e.g. "N123E1234", "S1234", "N123-E1234", "N123 E1234", "E1234A"


### PR DESCRIPTION
Implements regex for Bulgarian housenumbers, as specified in https://github.com/streetcomplete/StreetComplete/issues/5683#issuecomment-2163488046:

> - numbers followed by one Cyrillic letter (А, Б, а are the most common) directly or separated by a space or hyphen (-)
> - numbers preceded by "бл.", optionally separated by a space, and optionally followed by one Cyrillic letter directly or separated by a space or hyphen
> - numbers separated by hyphens (such as "2-4", "2-4-6")

_(tested on https://regex101.com/ by adding `^(?:` at the beginning and `)$` at the end, to match whole strings only, i.e. https://regex101.com/r/HstBiZ/2)_