### PR TITLE
further housenumber limits for Bulgaria

### DIFF
--- a/data/additionalValidHousenumberRegex.yml
+++ b/data/additionalValidHousenumberRegex.yml
@@ -6,7 +6,7 @@
 # in Australia, the unit number (sometimes?) prefixes the housenumber proper e.g. 1/50, see https://github.com/streetcomplete/StreetComplete/issues/4196
 AU: '([\p{N}\p{L}]{1,2}\s?/\s?|\p{L}{1,2}\s?)?\p{N}{1,5}'
 # see https://github.com/streetcomplete/StreetComplete/issues/5683#issuecomment-2163488046
-BG: '((бл\.\s?)?\p{N}{1,4}[\s-]?\p{Cyrillic}?)|((\p{N}{1,4}-){0,2}\p{N}{1,4})'
+BG: '((бл\.\s?)?\p{N}{1,4}[\s-]?\p{InCyrillic}?)|((\p{N}{1,4}-){0,2}\p{N}{1,4})'
 ES: 's/n'
 FR: '\p{N}{1,4}\sbis'
 # e.g. "N123E1234", "S1234", "N123-E1234", "N123 E1234", "E1234A"

--- a/data/additionalValidHousenumberRegex.yml
+++ b/data/additionalValidHousenumberRegex.yml
@@ -6,7 +6,7 @@
 # in Australia, the unit number (sometimes?) prefixes the housenumber proper e.g. 1/50, see https://github.com/streetcomplete/StreetComplete/issues/4196
 AU: '([\p{N}\p{L}]{1,2}\s?/\s?|\p{L}{1,2}\s?)?\p{N}{1,5}'
 # see https://github.com/streetcomplete/StreetComplete/issues/5683#issuecomment-2163488046
-BG: '((бл\.\s?)?\p{N}{1,4}[\s-]?\p{L}?)|((\p{N}{1,4}-)*\p{N}{1,4})'
+BG: '((бл\.\s?)?\p{N}{1,4}[\s-]?\p{Cyrillic}?)|((\p{N}{1,4}-){0,2}\p{N}{1,4})'
 ES: 's/n'
 FR: '\p{N}{1,4}\sbis'
 # e.g. "N123E1234", "S1234", "N123-E1234", "N123 E1234", "E1234A"


### PR DESCRIPTION
As indicated by @rhhsm in https://github.com/streetcomplete/countrymetadata/pull/26#issuecomment-2171816800 it adds following restrictions:

- only allow Cyrillic letters (no Latin ones)
- limit _"2-4-6"_ format to two dashes (so e.g. _"2-4-6"_ will match, but _"2-4-6-8"_ won't).

One can try it out how it works at:
https://regex101.com/r/HstBiZ/3

Would you @rhhsm please try it out and confirm if it **matches** on all things that it should match (green _"match"_ text at the top after you type your address in lower _"test string"_ window), and **does not match** when it shouldn't (grey _"no match"_ text)?

---

Notes:
- Kotlin [supposedly](https://stackoverflow.com/a/65642540/2600099) uses `\p{InCyrillic}` instead of `\p{Cyrillic}` - e.g. https://ideone.com/j7GjUE, so I've changed that from regex101.com example above given for testing
- in unlikely case `\p{InCyrillic}` happens not to be supported in our version of Kotlin, it could probably be replaced by character class `[\x{0400}-\x{04ff}]` to match whole [Cyrillic set](https://en.wikipedia.org/wiki/Cyrillic_script_in_Unicode) in most cases, but that might have caveats and is ugly, even if more portable, so I'd like to avoid it)