### PR TITLE
Fix Israel country code

### DIFF
--- a/data/mobileCountryCode.yml
+++ b/data/mobileCountryCode.yml
@@ -100,7 +100,7 @@ HT: 372
 HU: 216
 ID: 510
 IE: 272
-IL: 425
+IL: 972
 #IM: 234 # British
 IN: 404 #...405
 #IO: 995 # British. There appears to be no officially assigned MCC


### PR DESCRIPTION
Israel country code is +972 and not +425.
It was wrong on [WIkipedia](https://en.wikipedia.org/wiki/Mobile_country_code), and it was copied wrongly to street complete.

Sources:
* https://countrycode.org/israel
* https://www.worldometers.info/country-codes/israel-country-code/
* https://en.wikipedia.org/wiki/List_of_telephone_country_codes (another Wiki page where it is 972)